### PR TITLE
Adding ssl-default-bind-options

### DIFF
--- a/templates/defaults.cfg
+++ b/templates/defaults.cfg
@@ -82,5 +82,10 @@ defaults
 {% if haproxy_defaults.http_check.send_state is defined and haproxy_defaults.http_check.send_state == true %}
     http-check send-state
 {% endif -%}
+{% if haproxy_defaults.ssl_bind_options is defined %}
+{% for option in haproxy_defaults.ssl_bind_options %}
+    ssl-default-bind-options {{ option }}
+{% endfor -%}
+{% endif -%}
 {% endif -%}
 


### PR DESCRIPTION
Adding ssl-default-bind-options is necessary to disable insecure SSL/TLS versions.
