### PR TITLE
Fix tune config error in global config

### DIFF
--- a/filter_plugins/haproxy_flatten.py
+++ b/filter_plugins/haproxy_flatten.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 
-def flatten(d, separator='.'):
+def haproxy_flatten(d, separator='.'):
     """
     Flatten a dictionary `d` by joining nested keys with `separator`.
 
     Slightly modified from <http://codereview.stackexchange.com/a/21035>.
 
-    >>> flatten({'eggs': 'spam', 'sausage': {'eggs': 'bacon'}, 'spam': {'bacon': {'sausage': 'spam'}}})
+    >>> haproxy_flatten({'eggs': 'spam', 'sausage': {'eggs': 'bacon'}, 'spam': {'bacon': {'sausage': 'spam'}}})
     {'spam.bacon.sausage': 'spam', 'eggs': 'spam', 'sausage.eggs': 'bacon'}
     """
     def items():
         for k, v in d.items():
             try:
-                for sub_k, sub_v in flatten(v, separator).items():
+                for sub_k, sub_v in haproxy_flatten(v, separator).items():
                     yield separator.join([k, sub_k]), sub_v
             except AttributeError:
                 yield k, v
@@ -21,4 +21,4 @@ def flatten(d, separator='.'):
 
 class FilterModule(object):
     def filters(self):
-        return {'flatten': flatten}
+        return {'haproxy_flatten': haproxy_flatten}

--- a/templates/global.cfg
+++ b/templates/global.cfg
@@ -58,7 +58,7 @@ global
     ssl-default-server-ciphers {{ haproxy_global.ssl_default_server_ciphers }}
 {% endif -%}
 {% if haproxy_global.tune is defined %}
-    {% for param, value in (haproxy_global.tune | flatten).items() -%}
+    {% for param, value in (haproxy_global.tune | haproxy_flatten).items() -%}
     tune.{{ param }} {{ value }}
     {% endfor -%}
 {% endif %}


### PR DESCRIPTION
When trying to deploy what's we have now, running Ansible gives the following error:
```
TASK [mbainter.haproxy : Build up the global config] ************************************************************************
task path: /home/davina/.ansible/roles/mbainter.haproxy/tasks/configure.yml:118
fatal: [10.88.144.159]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'list object' has no attribute 'items'"}
fatal: [10.88.144.160]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'list object' has no attribute 'items'"}
```

That appears to be the same issue as listed here and their fix worked locally:
https://github.com/devops-coop/ansible-haproxy/issues/112